### PR TITLE
Accepts "tweet.js" instead of "tweets.csv"

### DIFF
--- a/deletetweets.py
+++ b/deletetweets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import csv
+import json
 import sys
 import time
 import os
@@ -11,19 +11,18 @@ from dateutil.parser import parse
 __author__ = "Koen Rouwhorst"
 __version__ = "0.1"
 
-def delete(api, date, r):
-    with open("tweets.csv") as file:
+def delete(api, date):   
+    with open("tweet.js") as file:
         count = 0
 
-        for row in csv.DictReader(file):
-            tweet_id = int(row["tweet_id"])
-            tweet_date = parse(row["timestamp"], ignoretz=True).date()
+        file_string = file.read().replace('window.YTD.tweet.part0 = ', '')
+        tweet_list = json.loads(file_string)
+
+        for tweet in tweet_list:
+            tweet_id = tweet['id']
+            tweet_date = parse(tweet['created_at'], ignoretz=True).date()
 
             if date != "" and tweet_date >= parse(date).date():
-                continue
-
-            if (r == "retweet" and row["retweeted_status_id"] == "" or
-                    r == "reply" and row["in_reply_to_status_id"] == ""):
                 continue
 
             try:
@@ -46,8 +45,6 @@ def main():
     parser = argparse.ArgumentParser(description="Delete old tweets.")
     parser.add_argument("-d", dest="date", required=True,
                         help="Delete tweets until this date")
-    parser.add_argument("-r", dest="restrict", choices=["reply", "retweet"],
-                        help="Restrict to either replies or retweets")
 
     args = parser.parse_args()
 
@@ -56,8 +53,7 @@ def main():
                       access_token_key="",
                       access_token_secret="")
 
-    delete(api, args.date, args.restrict)
-
+    delete(api, args.date)
 
 if __name__ == "__main__":
     main()

--- a/tweets.csv
+++ b/tweets.csv
@@ -1,2 +1,0 @@
-"tweet_id","in_reply_to_status_id","in_reply_to_user_id","timestamp","source","text","retweeted_status_id","retweeted_status_user_id","retweeted_status_timestamp","expanded_urls"
-"1","","","2014-01-01 00:00:00 +0000","<a href=""http://tapbots.com/software/tweetbot/mac"" rel=""nofollow"">Tweetbot for Mac</a>","Tweet","","","",""


### PR DESCRIPTION
Now when you request your data from Twitter instead of providing a .csv file it provides a .js, so I updated the code to work with that.

I know you're not maintaining this anymore, but when you Google "mass delete tweets" or things like that your tutorial is the first thing to show, so it would be cool to have this updated. The only extra hassle you'd have would be to update the tutorial and change "tweets.csv" to "tweet.js".

I removed the flag -r because it would take some extra work to make it work with the new data model Twitter is using, and as this wasn't mentioned on the tutorial I figured no one would miss it. But if you consider it imperative I could re implement it.